### PR TITLE
Fix GraphicsContext usage in canvas rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# ntruth-xnip
+# SnapPro 初始工程骨架
+
+本仓库提供 macOS 截图与标注工具 **SnapPro** 的初始工程结构，覆盖核心模块的 Swift Package 架构与一套可运行的基础功能（区域截图、简易标注、复制/保存与全局快捷键桩）。
+
+## 结构概览
+
+```
+SnapPro/
+├─ App/                       # SwiftUI App 入口与 UI
+├─ Packages/                  # 模块化 Swift Packages（CaptureKit/Annotator 等）
+└─ Tests/                     # 预留测试目录
+```
+
+各模块功能说明：
+
+- **CaptureKit**：区域/窗口/全屏截图与权限检测。
+- **ScrollCapture**：滚动截图控制器与拼接桩实现。
+- **Annotator**：标注模型、工具栏与画布渲染。
+- **ExportKit**：导出、命名模板与剪贴板能力。
+- **OCRKit**：基于 Vision 的 OCR 桩实现。
+- **Integration**：全局快捷键、菜单栏与首启引导。
+- **SnapProCore**：应用级环境与设置存储。
+
+## 快速开始
+
+1. 使用 Xcode 打开 `SnapPro` 目录下的工程（可自行创建 `.xcodeproj` 并引入各 Swift Package）。
+2. 为 `App` target 配置签名与沙盒权限（屏幕录制）。
+3. 运行后可通过菜单栏或快捷键 `⌥⇧⌘1` 启动区域截图，并在编辑器中添加标注。
+
+## 后续规划
+
+- 完成滚动截图的辅助功能驱动与图像拼接。
+- 丰富标注工具属性（样式、撤销/重做）。
+- 扩展导出格式与自动上传能力。
+- 优化 OCR 识别质量与多语言支持。
+- 建立自动化测试与基准评估。

--- a/SnapPro/App/AppDelegate.swift
+++ b/SnapPro/App/AppDelegate.swift
@@ -1,0 +1,16 @@
+import AppKit
+import Integration
+import CaptureKit
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private let hotkeyManager = HotkeyManager()
+    private let screenPermission = ScreenRecordingPermission()
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        screenPermission.ensureAuthorizedIfNeeded()
+        CaptureService.shared.onCapture = { image in
+            EditorWindow.present(with: image)
+        }
+        hotkeyManager.registerDefaults()
+    }
+}

--- a/SnapPro/App/ContentView.swift
+++ b/SnapPro/App/ContentView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import SnapProCore
+import CaptureKit
+
+struct ContentView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("SnapPro")
+                .font(.headline)
+            Text("快速截图与标注工具")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Divider()
+            Button("区域截图 (⌥⇧⌘1)") {
+                CaptureService.shared.captureRegion()
+            }
+            Button("窗口截图 (⌥⇧⌘2)") {
+                CaptureService.shared.captureWindow()
+            }
+            Button("全屏截图 (⌥⇧⌘3)") {
+                CaptureService.shared.captureScreen()
+            }
+            Divider()
+            Toggle("开机自动启动", isOn: $environment.settings.launchAtLogin)
+            Spacer()
+        }
+        .padding(16)
+        .frame(width: 280)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .environmentObject(AppEnvironment.preview)
+    }
+}

--- a/SnapPro/App/Editors/EditorWindow.swift
+++ b/SnapPro/App/Editors/EditorWindow.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import AppKit
+import Annotator
+
+public enum EditorWindow {
+    private static var controller: NSWindowController?
+
+    public static func present(with image: NSImage) {
+        let view = EditorView(baseImage: image)
+        let hosting = NSHostingView(rootView: view)
+
+        let window = NSWindow(contentRect: .init(x: 0, y: 0, width: 960, height: 640),
+                              styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                              backing: .buffered,
+                              defer: false)
+        window.center()
+        window.title = "SnapPro 编辑器"
+        window.contentView = hosting
+
+        controller = NSWindowController(window: window)
+        controller?.showWindow(nil)
+    }
+}

--- a/SnapPro/App/Info.plist
+++ b/SnapPro/App/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>SnapPro</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/SnapPro/App/Resources/Localizations/Base.lproj/Localizable.strings
+++ b/SnapPro/App/Resources/Localizations/Base.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"app_name" = "SnapPro";
+"menu_quick_capture" = "Quick Capture";

--- a/SnapPro/App/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/SnapPro/App/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"app_name" = "SnapPro";
+"menu_quick_capture" = "快速截图";

--- a/SnapPro/App/SettingsView.swift
+++ b/SnapPro/App/SettingsView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import SnapProCore
+
+struct SettingsView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+
+    var body: some View {
+        Form {
+            Section("导出") {
+                Picker("默认格式", selection: $environment.settings.defaultExportFormat) {
+                    ForEach(AppSettings.ExportFormat.allCases, id: \.self) { format in
+                        Text(format.displayName).tag(format)
+                    }
+                }
+                Toggle("自动保存到默认目录", isOn: $environment.settings.autoSave)
+            }
+            Section("快捷键") {
+                Toggle("启用全局快捷键", isOn: $environment.settings.enableHotkeys)
+            }
+        }
+        .padding(24)
+        .frame(width: 420)
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
+            .environmentObject(AppEnvironment.preview)
+    }
+}

--- a/SnapPro/App/SnapProApp.swift
+++ b/SnapPro/App/SnapProApp.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import SnapProCore
+import Integration
+
+@main
+struct SnapProApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @StateObject private var environment = AppEnvironment.live
+
+    var body: some Scene {
+        MenuBarExtra("SnapPro", systemImage: "camera") {
+            ContentView()
+                .environmentObject(environment)
+        }
+        .menuBarExtraStyle(.window)
+
+        Settings {
+            SettingsView()
+                .environmentObject(environment)
+        }
+    }
+}

--- a/SnapPro/Packages/Annotator/Package.swift
+++ b/SnapPro/Packages/Annotator/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Annotator",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "Annotator", targets: ["Annotator"])
+    ],
+    dependencies: [
+        .package(path: "../SnapProCore")
+    ],
+    targets: [
+        .target(name: "Annotator", dependencies: ["SnapProCore"])
+    ]
+)

--- a/SnapPro/Packages/Annotator/Sources/Annotator/CanvasView.swift
+++ b/SnapPro/Packages/Annotator/Sources/Annotator/CanvasView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import SnapProCore
+
+public struct EditorView: View {
+    public let baseImage: NSImage
+    @State private var shapes: [AnyShape] = []
+    @State private var selectedTool: Tool = .rectangle
+
+    public init(baseImage: NSImage) {
+        self.baseImage = baseImage
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            ToolboxView(selectedTool: $selectedTool)
+            Canvas { context, size in
+                if let cg = baseImage.cgImage() {
+                    context.draw(Image(decorative: cg, scale: 1, orientation: .up), at: .zero, anchor: .topLeading)
+                }
+                for shape in shapes {
+                    context.drawLayer { layerContext in
+                        shape.draw(in: &layerContext)
+                    }
+                }
+            }
+            .frame(minWidth: 640, minHeight: 400)
+            .gesture(DragGesture(minimumDistance: 0).onEnded { value in
+                addShape(at: value.location)
+            })
+        }
+    }
+
+    private func addShape(at point: CGPoint) {
+        let frame = CGRect(origin: CGPoint(x: max(point.x - 60, 0), y: max(point.y - 40, 0)),
+                           size: CGSize(width: 120, height: 80))
+        switch selectedTool {
+        case .rectangle:
+            shapes.append(AnyShape(RectShape(frame: frame)))
+        case .arrow:
+            shapes.append(AnyShape(ArrowShape(frame: frame)))
+        case .text:
+            shapes.append(AnyShape(TextShape(frame: frame, text: "文本")))
+        case .blur:
+            shapes.append(AnyShape(BlurShape(frame: frame)))
+        }
+    }
+}
+
+struct AnyShape: ShapeModel {
+    private var frameGetter: () -> CGRect
+    private var frameSetter: (CGRect) -> Void
+    private var drawer: (inout GraphicsContext) -> Void
+    public let id: UUID
+
+    init<S: ShapeModel>(_ shape: S) {
+        var mutableShape = shape
+        id = shape.id
+        frameGetter = { mutableShape.frame }
+        frameSetter = { mutableShape.frame = $0 }
+        drawer = { context in mutableShape.draw(in: &context) }
+    }
+
+    var frame: CGRect {
+        get { frameGetter() }
+        set { frameSetter(newValue) }
+    }
+
+    func draw(in context: inout GraphicsContext) {
+        drawer(&context)
+    }
+}
+
+public enum Tool: CaseIterable {
+    case rectangle
+    case arrow
+    case text
+    case blur
+}

--- a/SnapPro/Packages/Annotator/Sources/Annotator/Models/ArrowShape.swift
+++ b/SnapPro/Packages/Annotator/Sources/Annotator/Models/ArrowShape.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+public struct ArrowShape: ShapeModel {
+    public let id: UUID
+    public var frame: CGRect
+    public var color: Color
+    public var lineWidth: CGFloat
+
+    public init(frame: CGRect, color: Color = .yellow, lineWidth: CGFloat = 3) {
+        self.id = UUID()
+        self.frame = frame
+        self.color = color
+        self.lineWidth = lineWidth
+    }
+
+    public func draw(in context: inout GraphicsContext) {
+        var path = Path()
+        let start = CGPoint(x: frame.minX, y: frame.midY)
+        let end = CGPoint(x: frame.maxX, y: frame.midY)
+        path.move(to: start)
+        path.addLine(to: end)
+
+        let arrowSize: CGFloat = max(6, min(frame.width, frame.height) * 0.25)
+        path.move(to: CGPoint(x: end.x - arrowSize, y: end.y + arrowSize / 2))
+        path.addLine(to: end)
+        path.addLine(to: CGPoint(x: end.x - arrowSize, y: end.y - arrowSize / 2))
+        context.stroke(path, with: .color(color), lineWidth: lineWidth)
+    }
+}

--- a/SnapPro/Packages/Annotator/Sources/Annotator/Models/BlurShape.swift
+++ b/SnapPro/Packages/Annotator/Sources/Annotator/Models/BlurShape.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+public struct BlurShape: ShapeModel {
+    public let id: UUID
+    public var frame: CGRect
+    public var radius: CGFloat
+
+    public init(frame: CGRect, radius: CGFloat = 8) {
+        self.id = UUID()
+        self.frame = frame
+        self.radius = radius
+    }
+
+    public func draw(in context: inout GraphicsContext) {
+        let path = Path(frame)
+        context.addFilter(.blur(radius: radius))
+        context.fill(path, with: .color(.black.opacity(0.5)))
+    }
+}

--- a/SnapPro/Packages/Annotator/Sources/Annotator/Models/RectShape.swift
+++ b/SnapPro/Packages/Annotator/Sources/Annotator/Models/RectShape.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+public struct RectShape: ShapeModel {
+    public let id: UUID
+    public var frame: CGRect
+    public var color: Color
+    public var lineWidth: CGFloat
+
+    public init(frame: CGRect, color: Color = .red, lineWidth: CGFloat = 2) {
+        self.id = UUID()
+        self.frame = frame
+        self.color = color
+        self.lineWidth = lineWidth
+    }
+
+    public func draw(in context: inout GraphicsContext) {
+        let path = Path(frame)
+        context.stroke(path, with: .color(color), lineWidth: lineWidth)
+    }
+}

--- a/SnapPro/Packages/Annotator/Sources/Annotator/Models/Shape.swift
+++ b/SnapPro/Packages/Annotator/Sources/Annotator/Models/Shape.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+public protocol ShapeModel: Identifiable {
+    var id: UUID { get }
+    var frame: CGRect { get set }
+    func draw(in context: inout GraphicsContext)
+}

--- a/SnapPro/Packages/Annotator/Sources/Annotator/Models/TextShape.swift
+++ b/SnapPro/Packages/Annotator/Sources/Annotator/Models/TextShape.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+public struct TextShape: ShapeModel {
+    public let id: UUID
+    public var frame: CGRect
+    public var text: String
+    public var color: Color
+    public var fontSize: CGFloat
+
+    public init(frame: CGRect, text: String, color: Color = .white, fontSize: CGFloat = 16) {
+        self.id = UUID()
+        self.frame = frame
+        self.text = text
+        self.color = color
+        self.fontSize = fontSize
+    }
+
+    public func draw(in context: inout GraphicsContext) {
+        let nsColor = NSColor(color)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: fontSize, weight: .medium),
+            .foregroundColor: nsColor
+        ]
+        let attributed = NSAttributedString(string: text, attributes: attributes)
+        context.draw(Text(attributed), in: frame)
+    }
+}

--- a/SnapPro/Packages/Annotator/Sources/Annotator/ToolboxView.swift
+++ b/SnapPro/Packages/Annotator/Sources/Annotator/ToolboxView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+public struct ToolboxView: View {
+    @Binding var selectedTool: Tool
+
+    public init(selectedTool: Binding<Tool>) {
+        _selectedTool = selectedTool
+    }
+
+    public var body: some View {
+        HStack(spacing: 12) {
+            ForEach(Tool.allCases, id: \.self) { tool in
+                Button(action: { selectedTool = tool }) {
+                    Label(tool.title, systemImage: tool.icon)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(selectedTool == tool ? .accentColor : .gray)
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(Material.bar)
+    }
+}
+
+private extension Tool {
+    var title: String {
+        switch self {
+        case .rectangle: return "矩形"
+        case .arrow: return "箭头"
+        case .text: return "文本"
+        case .blur: return "马赛克"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .rectangle: return "square"
+        case .arrow: return "arrow.right"
+        case .text: return "textformat"
+        case .blur: return "drop"
+        }
+    }
+}

--- a/SnapPro/Packages/CaptureKit/Package.swift
+++ b/SnapPro/Packages/CaptureKit/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "CaptureKit",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "CaptureKit", targets: ["CaptureKit"])
+    ],
+    targets: [
+        .target(name: "CaptureKit")
+    ]
+)

--- a/SnapPro/Packages/CaptureKit/Sources/CaptureKit/CaptureService.swift
+++ b/SnapPro/Packages/CaptureKit/Sources/CaptureKit/CaptureService.swift
@@ -1,0 +1,31 @@
+import AppKit
+
+public final class CaptureService {
+    public static let shared = CaptureService()
+
+    public var onCapture: ((NSImage) -> Void)?
+
+    private init() {}
+
+    public func captureRegion() {
+        RegionSelectionOverlay.present { [weak self] image in
+            self?.onCapture?(image)
+        }
+    }
+
+    public func captureWindow() {
+        WindowPicker.pick { [weak self] image in
+            guard let image else { return }
+            self?.onCapture?(image)
+        }
+    }
+
+    public func captureScreen() {
+        guard let screen = NSScreen.main else { return }
+        let rect = screen.frame
+        guard let cgImage = CGWindowListCreateImage(rect, .optionOnScreenOnly, kCGNullWindowID, [.bestResolution]) else {
+            return
+        }
+        onCapture?(NSImage(cgImage: cgImage, size: rect.size))
+    }
+}

--- a/SnapPro/Packages/CaptureKit/Sources/CaptureKit/Permissions/ScreenRecordingPermission.swift
+++ b/SnapPro/Packages/CaptureKit/Sources/CaptureKit/Permissions/ScreenRecordingPermission.swift
@@ -1,0 +1,13 @@
+import AppKit
+import ApplicationServices
+
+public final class ScreenRecordingPermission {
+    public init() {}
+
+    public func ensureAuthorizedIfNeeded() {
+        guard CGPreflightScreenCaptureAccess() else {
+            CGRequestScreenCaptureAccess()
+            return
+        }
+    }
+}

--- a/SnapPro/Packages/CaptureKit/Sources/CaptureKit/RegionSelectionOverlay.swift
+++ b/SnapPro/Packages/CaptureKit/Sources/CaptureKit/RegionSelectionOverlay.swift
@@ -1,0 +1,94 @@
+import AppKit
+
+public enum RegionSelectionOverlay {
+    private static var activeWindows: [SelectionWindow] = []
+
+    public static func present(on screen: NSScreen? = NSScreen.main, completion: @escaping (NSImage) -> Void) {
+        guard let screen else { return }
+        let overlay = SelectionWindow(screen: screen)
+        overlay.onFinish = { image in
+            completion(image)
+            if let index = activeWindows.firstIndex(where: { $0 === overlay }) {
+                activeWindows.remove(at: index)
+            }
+        }
+        activeWindows.append(overlay)
+        overlay.makeKeyAndOrderFront(nil)
+        overlay.beginSelection()
+    }
+}
+
+private final class SelectionWindow: NSPanel {
+    fileprivate var onFinish: ((NSImage) -> Void)?
+    private let selectionView = SelectionView()
+
+    init(screen: NSScreen) {
+        super.init(contentRect: screen.frame, styleMask: [.borderless], backing: .buffered, defer: true)
+        level = .statusBar
+        isOpaque = false
+        backgroundColor = .clear
+        ignoresMouseEvents = false
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        contentView = selectionView
+    }
+
+    func beginSelection() {
+        makeKey()
+        selectionView.onComplete = { [weak self] rect in
+            guard let self else { return }
+            self.orderOut(nil)
+            guard rect.width > 1, rect.height > 1 else { return }
+            guard let cgImage = CGWindowListCreateImage(rect, .optionOnScreenOnly, kCGNullWindowID, [.bestResolution]) else { return }
+            let image = NSImage(cgImage: cgImage, size: rect.size)
+            onFinish?(image)
+        }
+    }
+}
+
+private final class SelectionView: NSView {
+    var onComplete: ((CGRect) -> Void)?
+    private var startPoint: CGPoint?
+    private var currentRect: CGRect = .zero {
+        didSet { needsDisplay = true }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        NSColor.black.withAlphaComponent(0.4).setFill()
+        dirtyRect.fill()
+        if currentRect != .zero {
+            NSColor.clear.setFill()
+            NSBezierPath(rect: currentRect).addClip()
+            NSColor(calibratedWhite: 0, alpha: 0.6).setFill()
+            bounds.fill()
+            NSColor.systemBlue.setStroke()
+            NSBezierPath(rect: currentRect).stroke()
+        }
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        startPoint = convert(event.locationInWindow, from: nil)
+        currentRect = .zero
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let start = startPoint else { return }
+        let current = convert(event.locationInWindow, from: nil)
+        currentRect = CGRect(x: min(start.x, current.x),
+                             y: min(start.y, current.y),
+                             width: abs(start.x - current.x),
+                             height: abs(start.y - current.y))
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        onComplete?(currentRect)
+    }
+}

--- a/SnapPro/Packages/CaptureKit/Sources/CaptureKit/WindowPicker.swift
+++ b/SnapPro/Packages/CaptureKit/Sources/CaptureKit/WindowPicker.swift
@@ -1,0 +1,28 @@
+import AppKit
+import ApplicationServices
+
+public enum WindowPicker {
+    public static func pick(completion: @escaping (NSImage?) -> Void) {
+        guard let screen = NSScreen.main else {
+            completion(nil)
+            return
+        }
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            completion(nil)
+            return
+        }
+        guard let windowInfo = windowList.first,
+              let windowID = windowInfo[kCGWindowNumber as String] as? CGWindowID else {
+            completion(nil)
+            return
+        }
+        let bounds = CGRect(origin: .zero, size: screen.frame.size)
+        let image = CGWindowListCreateImage(bounds, options, windowID, [.bestResolution])
+        if let image {
+            completion(NSImage(cgImage: image, size: bounds.size))
+        } else {
+            completion(nil)
+        }
+    }
+}

--- a/SnapPro/Packages/ExportKit/Package.swift
+++ b/SnapPro/Packages/ExportKit/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ExportKit",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "ExportKit", targets: ["ExportKit"])
+    ],
+    dependencies: [
+        .package(path: "../Annotator"),
+        .package(path: "../SnapProCore")
+    ],
+    targets: [
+        .target(name: "ExportKit", dependencies: ["Annotator", "SnapProCore"])
+    ]
+)

--- a/SnapPro/Packages/ExportKit/Sources/ExportKit/ClipboardService.swift
+++ b/SnapPro/Packages/ExportKit/Sources/ExportKit/ClipboardService.swift
@@ -1,0 +1,15 @@
+import AppKit
+
+public final class ClipboardService {
+    public init() {}
+
+    public func copyImage(_ image: NSImage) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.writeObjects([image])
+    }
+
+    public func copyText(_ text: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+}

--- a/SnapPro/Packages/ExportKit/Sources/ExportKit/ExportService.swift
+++ b/SnapPro/Packages/ExportKit/Sources/ExportKit/ExportService.swift
@@ -1,0 +1,83 @@
+import AppKit
+import SwiftUI
+import Annotator
+import SnapProCore
+
+public enum ExportFormat {
+    case png
+    case jpeg(quality: CGFloat)
+    case pdf
+}
+
+public final class ExportService {
+    public init() {}
+
+    public func export(baseImage: NSImage, shapes: [any ShapeModel], to url: URL, format: ExportFormat) throws {
+        switch format {
+        case .png:
+            try exportPNG(baseImage: baseImage, shapes: shapes, to: url)
+        case .jpeg(let quality):
+            try exportJPEG(baseImage: baseImage, shapes: shapes, to: url, quality: quality)
+        case .pdf:
+            try exportPDF(baseImage: baseImage, shapes: shapes, to: url)
+        }
+    }
+
+    private func renderComposite(baseImage: NSImage, shapes: [any ShapeModel]) -> NSImage? {
+        let renderer = ImageRenderer(content: AnnotatedCanvas(baseImage: baseImage, shapes: shapes))
+        renderer.proposedSize = .init(width: baseImage.size.width, height: baseImage.size.height)
+        renderer.scale = NSScreen.main?.backingScaleFactor ?? 2
+        return renderer.nsImage
+    }
+
+    private func exportPNG(baseImage: NSImage, shapes: [any ShapeModel], to url: URL) throws {
+        guard let combined = renderComposite(baseImage: baseImage, shapes: shapes),
+              let data = combined.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: data),
+              let pngData = bitmap.representation(using: .png, properties: [:]) else {
+            throw ExportError.renderFailed
+        }
+        try pngData.write(to: url)
+    }
+
+    private func exportJPEG(baseImage: NSImage, shapes: [any ShapeModel], to url: URL, quality: CGFloat) throws {
+        guard let combined = renderComposite(baseImage: baseImage, shapes: shapes),
+              let data = combined.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: data),
+              let jpegData = bitmap.representation(using: .jpeg, properties: [.compressionFactor: quality]) else {
+            throw ExportError.renderFailed
+        }
+        try jpegData.write(to: url)
+    }
+
+    private func exportPDF(baseImage: NSImage, shapes: [any ShapeModel], to url: URL) throws {
+        guard let combined = renderComposite(baseImage: baseImage, shapes: shapes),
+              let pdfData = combined.dataWithPDF(inside: CGRect(origin: .zero, size: combined.size)) else {
+            throw ExportError.renderFailed
+        }
+        try pdfData.write(to: url, options: .atomic)
+    }
+}
+
+public enum ExportError: Error {
+    case renderFailed
+}
+
+private struct AnnotatedCanvas: View {
+    let baseImage: NSImage
+    let shapes: [any ShapeModel]
+
+    var body: some View {
+        Canvas { context, _ in
+            if let cgImage = baseImage.cgImage() {
+                context.draw(Image(decorative: cgImage, scale: 1, orientation: .up), at: .zero, anchor: .topLeading)
+            }
+            for shape in shapes {
+                context.drawLayer { layerContext in
+                    shape.draw(in: &layerContext)
+                }
+            }
+        }
+        .frame(width: baseImage.size.width, height: baseImage.size.height, alignment: .topLeading)
+    }
+}

--- a/SnapPro/Packages/ExportKit/Sources/ExportKit/NamingTemplate.swift
+++ b/SnapPro/Packages/ExportKit/Sources/ExportKit/NamingTemplate.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public struct NamingTemplate {
+    private let dateProvider: () -> Date
+
+    public init(dateProvider: @escaping () -> Date = Date.init) {
+        self.dateProvider = dateProvider
+    }
+
+    public func render(_ template: String, context: [String: String]) -> String {
+        let pattern = #"\$\{([^}]+)\}"#
+        let regex = try? NSRegularExpression(pattern: pattern, options: [])
+        let fullRange = NSRange(location: 0, length: template.utf16.count)
+        var result = template
+        let date = dateProvider()
+        regex?.matches(in: template, options: [], range: fullRange).reversed().forEach { match in
+            guard match.numberOfRanges > 1,
+                  let range = Range(match.range(at: 0), in: template),
+                  let tokenRange = Range(match.range(at: 1), in: template) else { return }
+            let token = String(template[tokenRange])
+            let parts = token.split(separator: ":", maxSplits: 1).map(String.init)
+            let replacement: String
+            if parts.count == 2, let formatted = formatSpecialToken(parts[0], format: parts[1], date: date, context: context) {
+                replacement = formatted
+            } else if let formatted = formatSpecialToken(parts[0], format: nil, date: date, context: context) {
+                replacement = formatted
+            } else {
+                replacement = context[parts[0]] ?? ""
+            }
+            result.replaceSubrange(range, with: replacement)
+        }
+        return result
+    }
+
+    private func formatSpecialToken(_ key: String, format: String?, date: Date, context: [String: String]) -> String? {
+        switch key {
+        case "date":
+            let formatter = DateFormatter()
+            formatter.dateFormat = format ?? "yyyy-MM-dd"
+            return formatter.string(from: date)
+        case "time":
+            let formatter = DateFormatter()
+            formatter.dateFormat = format ?? "HH-mm-ss"
+            return formatter.string(from: date)
+        case "counter":
+            return context[key]
+        default:
+            return nil
+        }
+    }
+}

--- a/SnapPro/Packages/Integration/Package.swift
+++ b/SnapPro/Packages/Integration/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Integration",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "Integration", targets: ["Integration"])
+    ],
+    dependencies: [
+        .package(path: "../CaptureKit")
+    ],
+    targets: [
+        .target(name: "Integration", dependencies: ["CaptureKit"])
+    ]
+)

--- a/SnapPro/Packages/Integration/Sources/Integration/HotkeyManager.swift
+++ b/SnapPro/Packages/Integration/Sources/Integration/HotkeyManager.swift
@@ -1,0 +1,30 @@
+import AppKit
+import CaptureKit
+
+public final class HotkeyManager {
+    private var monitor: Any?
+
+    public init() {}
+
+    public func registerDefaults() {
+        monitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+            guard event.modifierFlags.contains([.command, .option, .shift]) else { return }
+            switch event.keyCode {
+            case 18: // 1
+                CaptureService.shared.captureRegion()
+            case 19: // 2
+                CaptureService.shared.captureWindow()
+            case 20: // 3
+                CaptureService.shared.captureScreen()
+            default:
+                break
+            }
+        }
+    }
+
+    deinit {
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+}

--- a/SnapPro/Packages/Integration/Sources/Integration/MenuBarController.swift
+++ b/SnapPro/Packages/Integration/Sources/Integration/MenuBarController.swift
@@ -1,0 +1,13 @@
+import AppKit
+
+public final class MenuBarController {
+    private var statusItem: NSStatusItem?
+
+    public init() {}
+
+    public func setup() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        statusItem?.button?.image = NSImage(systemSymbolName: "camera.fill", accessibilityDescription: "SnapPro")
+        statusItem?.button?.toolTip = "SnapPro"
+    }
+}

--- a/SnapPro/Packages/Integration/Sources/Integration/OnboardingGuide.swift
+++ b/SnapPro/Packages/Integration/Sources/Integration/OnboardingGuide.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+public struct OnboardingGuide: View {
+    public init() {}
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            Text("欢迎使用 SnapPro")
+                .font(.title)
+            Text("请在系统设置中授予屏幕录制和辅助功能权限，以便进行截图和滚动捕获。")
+                .multilineTextAlignment(.center)
+        }
+        .padding(32)
+    }
+}

--- a/SnapPro/Packages/OCRKit/Package.swift
+++ b/SnapPro/Packages/OCRKit/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "OCRKit",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "OCRKit", targets: ["OCRKit"])
+    ],
+    targets: [
+        .target(name: "OCRKit")
+    ]
+)

--- a/SnapPro/Packages/OCRKit/Sources/OCRKit/OCRService.swift
+++ b/SnapPro/Packages/OCRKit/Sources/OCRKit/OCRService.swift
@@ -1,0 +1,5 @@
+import AppKit
+
+public protocol OCRService {
+    func recognize(in image: NSImage, languages: [String]) async throws -> String
+}

--- a/SnapPro/Packages/OCRKit/Sources/OCRKit/VisionOCR.swift
+++ b/SnapPro/Packages/OCRKit/Sources/OCRKit/VisionOCR.swift
@@ -1,0 +1,19 @@
+import Vision
+import AppKit
+
+public final class VisionOCR: OCRService {
+    public init() {}
+
+    public func recognize(in image: NSImage, languages: [String]) async throws -> String {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return ""
+        }
+        let request = VNRecognizeTextRequest()
+        request.recognitionLanguages = languages
+        request.usesLanguageCorrection = true
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        try handler.perform([request])
+        let observations = request.results ?? []
+        return observations.compactMap { $0.topCandidates(1).first?.string }.joined(separator: "\n")
+    }
+}

--- a/SnapPro/Packages/ScrollCapture/Package.swift
+++ b/SnapPro/Packages/ScrollCapture/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ScrollCapture",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "ScrollCapture", targets: ["ScrollCapture"])
+    ],
+    targets: [
+        .target(name: "ScrollCapture")
+    ]
+)

--- a/SnapPro/Packages/ScrollCapture/Sources/ScrollCapture/ScrollController.swift
+++ b/SnapPro/Packages/ScrollCapture/Sources/ScrollCapture/ScrollController.swift
@@ -1,0 +1,11 @@
+import AppKit
+import ApplicationServices
+
+public final class ScrollController {
+    public init() {}
+
+    public func captureFullContent(of view: AXUIElement, on screen: NSScreen, completion: @escaping (NSImage?) -> Void) {
+        // Stub implementation: future work to drive accessibility scroll and capture segments.
+        completion(nil)
+    }
+}

--- a/SnapPro/Packages/ScrollCapture/Sources/ScrollCapture/SegmentCapture.swift
+++ b/SnapPro/Packages/ScrollCapture/Sources/ScrollCapture/SegmentCapture.swift
@@ -1,0 +1,21 @@
+import AppKit
+import ApplicationServices
+
+public struct CaptureSegment {
+    public var image: NSImage
+    public var origin: CGPoint
+
+    public init(image: NSImage, origin: CGPoint) {
+        self.image = image
+        self.origin = origin
+    }
+}
+
+public final class SegmentCapture {
+    public init() {}
+
+    public func captureSegments(for view: AXUIElement) -> [CaptureSegment] {
+        // Placeholder segments until implementation is provided.
+        return []
+    }
+}

--- a/SnapPro/Packages/ScrollCapture/Sources/ScrollCapture/Stitcher.swift
+++ b/SnapPro/Packages/ScrollCapture/Sources/ScrollCapture/Stitcher.swift
@@ -1,0 +1,21 @@
+import AppKit
+
+public final class Stitcher {
+    public init() {}
+
+    public func stitch(segments: [CaptureSegment]) -> NSImage? {
+        guard !segments.isEmpty else { return nil }
+        let totalHeight = segments.reduce(CGFloat.zero) { $0 + $1.image.size.height }
+        let width = segments.first?.image.size.width ?? 0
+        let size = CGSize(width: width, height: totalHeight)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        var y: CGFloat = totalHeight
+        for segment in segments {
+            y -= segment.image.size.height
+            segment.image.draw(at: NSPoint(x: 0, y: y), from: .zero, operation: .copy, fraction: 1.0)
+        }
+        image.unlockFocus()
+        return image
+    }
+}

--- a/SnapPro/Packages/SnapProCore/Package.swift
+++ b/SnapPro/Packages/SnapProCore/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "SnapProCore",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "SnapProCore", targets: ["SnapProCore"])
+    ],
+    targets: [
+        .target(name: "SnapProCore"),
+        .testTarget(name: "SnapProCoreTests", dependencies: ["SnapProCore"], path: "Tests")
+    ]
+)

--- a/SnapPro/Packages/SnapProCore/Sources/SnapProCore/AppEnvironment.swift
+++ b/SnapPro/Packages/SnapProCore/Sources/SnapProCore/AppEnvironment.swift
@@ -1,0 +1,58 @@
+import Combine
+import Foundation
+
+public final class AppEnvironment: ObservableObject {
+    public static var live: AppEnvironment = {
+        let store = SettingsStore()
+        let env = AppEnvironment(settings: store.load(), store: store)
+        return env
+    }()
+
+    public static let preview = AppEnvironment(settings: .preview)
+
+    @Published public var settings: AppSettings {
+        didSet { store.save(settings) }
+    }
+
+    private let store: SettingsStore
+
+    public init(settings: AppSettings, store: SettingsStore = SettingsStore()) {
+        self.settings = settings
+        self.store = store
+    }
+}
+
+public struct AppSettings: Equatable, Codable {
+    public enum ExportFormat: String, CaseIterable, Codable {
+        case png
+        case jpeg
+        case pdf
+
+        public var displayName: String {
+            switch self {
+            case .png: return "PNG"
+            case .jpeg: return "JPEG"
+            case .pdf: return "PDF"
+            }
+        }
+    }
+
+    public var defaultExportFormat: ExportFormat
+    public var autoSave: Bool
+    public var enableHotkeys: Bool
+    public var launchAtLogin: Bool
+
+    public init(defaultExportFormat: ExportFormat = .png,
+                autoSave: Bool = true,
+                enableHotkeys: Bool = true,
+                launchAtLogin: Bool = false) {
+        self.defaultExportFormat = defaultExportFormat
+        self.autoSave = autoSave
+        self.enableHotkeys = enableHotkeys
+        self.launchAtLogin = launchAtLogin
+    }
+}
+
+public extension AppSettings {
+    static let preview = AppSettings()
+}

--- a/SnapPro/Packages/SnapProCore/Sources/SnapProCore/Logging.swift
+++ b/SnapPro/Packages/SnapProCore/Sources/SnapProCore/Logging.swift
@@ -1,0 +1,18 @@
+import os.log
+
+fileprivate let logSubsystem = "com.snappro.app"
+
+public enum Log {
+    public static func capture(_ message: String) {
+        os_log("%{public}@", log: .capture, type: .info, message)
+    }
+
+    public static func error(_ message: String) {
+        os_log("%{public}@", log: .general, type: .error, message)
+    }
+}
+
+private extension OSLog {
+    static let general = OSLog(subsystem: logSubsystem, category: "general")
+    static let capture = OSLog(subsystem: logSubsystem, category: "capture")
+}

--- a/SnapPro/Packages/SnapProCore/Sources/SnapProCore/SettingsStore.swift
+++ b/SnapPro/Packages/SnapProCore/Sources/SnapProCore/SettingsStore.swift
@@ -1,0 +1,29 @@
+import Combine
+import Foundation
+
+public final class SettingsStore {
+    private enum Keys {
+        static let defaultsKey = "app.settings"
+    }
+
+    private let defaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func load() -> AppSettings {
+        guard let data = defaults.data(forKey: Keys.defaultsKey),
+              let settings = try? decoder.decode(AppSettings.self, from: data) else {
+            return .init()
+        }
+        return settings
+    }
+
+    public func save(_ settings: AppSettings) {
+        guard let data = try? encoder.encode(settings) else { return }
+        defaults.set(data, forKey: Keys.defaultsKey)
+    }
+}

--- a/SnapPro/Packages/SnapProCore/Sources/SnapProCore/Utilities/Image+Extensions.swift
+++ b/SnapPro/Packages/SnapProCore/Sources/SnapProCore/Utilities/Image+Extensions.swift
@@ -1,0 +1,8 @@
+import AppKit
+
+public extension NSImage {
+    func cgImage() -> CGImage? {
+        var proposedRect = CGRect(origin: .zero, size: size)
+        return cgImage(forProposedRect: &proposedRect, context: nil, hints: nil)
+    }
+}

--- a/SnapPro/Packages/SnapProCore/Sources/SnapProCore/Utilities/PixelGrid.swift
+++ b/SnapPro/Packages/SnapProCore/Sources/SnapProCore/Utilities/PixelGrid.swift
@@ -1,0 +1,27 @@
+import CoreGraphics
+
+public struct PixelGrid {
+    public var size: CGSize
+    public var spacing: CGFloat
+
+    public init(size: CGSize, spacing: CGFloat = 1) {
+        self.size = size
+        self.spacing = spacing
+    }
+
+    public func lines() -> [CGRect] {
+        var rects: [CGRect] = []
+        guard spacing > 0 else { return rects }
+        var x: CGFloat = 0
+        while x <= size.width {
+            rects.append(CGRect(x: x, y: 0, width: 0.5, height: size.height))
+            x += spacing
+        }
+        var y: CGFloat = 0
+        while y <= size.height {
+            rects.append(CGRect(x: 0, y: y, width: size.width, height: 0.5))
+            y += spacing
+        }
+        return rects
+    }
+}

--- a/SnapPro/Packages/SnapProCore/Tests/PlaceholderTests.swift
+++ b/SnapPro/Packages/SnapProCore/Tests/PlaceholderTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import SnapProCore
+
+final class PlaceholderTests: XCTestCase {
+    func testSettingsEncoding() throws {
+        let store = SettingsStore(defaults: UserDefaults(suiteName: "test")!)
+        let original = AppSettings(defaultExportFormat: .jpeg, autoSave: false, enableHotkeys: true, launchAtLogin: true)
+        store.save(original)
+        let loaded = store.load()
+        XCTAssertEqual(original, loaded)
+    }
+}


### PR DESCRIPTION
## Summary
- wrap shape drawing in Canvas drawLayer closures so we no longer copy GraphicsContext instances
- reuse the same approach in the export renderer to resolve GraphicsContext initializer errors

## Testing
- not run (macOS-specific project)


------
https://chatgpt.com/codex/tasks/task_e_68e47d3b062083208f057daf2c6e7cf1